### PR TITLE
Support Forge currentlyLoading field on chunks

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/world/chunk/ChunkHolderExtended.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/world/chunk/ChunkHolderExtended.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.lithium.common.world.chunk;
 import com.mojang.datafixers.util.Either;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.WorldChunk;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -25,4 +26,6 @@ public interface ChunkHolderExtended {
      * @return True if the chunk needs a new ticket to be created in order to retain it, otherwise false
      */
     boolean updateLastAccessTime(long time);
+
+    WorldChunk getCurrentlyLoading();
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/world/chunk_access/ChunkHolderMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/world/chunk_access/ChunkHolderMixin.java
@@ -4,6 +4,7 @@ import com.mojang.datafixers.util.Either;
 import me.jellysquid.mods.lithium.common.world.chunk.ChunkHolderExtended;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.WorldChunk;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -16,6 +17,9 @@ public class ChunkHolderMixin implements ChunkHolderExtended {
     @Shadow
     @Final
     private AtomicReferenceArray<CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>>> futuresByStatus;
+
+    @Shadow
+    WorldChunk currentlyLoading;
 
     private long lastRequestTime;
 
@@ -35,5 +39,10 @@ public class ChunkHolderMixin implements ChunkHolderExtended {
         this.lastRequestTime = time;
 
         return prev != time;
+    }
+
+    @Override
+    public WorldChunk getCurrentlyLoading() {
+        return this.currentlyLoading;
     }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/world/chunk_access/ServerChunkManagerMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/world/chunk_access/ServerChunkManagerMixin.java
@@ -129,6 +129,10 @@ public abstract class ServerChunkManagerMixin {
 
         ChunkHolder holder = this.getChunkHolder(key);
 
+        // Support Forge currentlyLoading field
+        if (holder != null && ((ChunkHolderExtended)holder).getCurrentlyLoading() != null)
+            return ((ChunkHolderExtended)holder).getCurrentlyLoading();
+
         // Check if the holder is present and is at least of the level we need
         if (this.isMissingForLevel(holder, level)) {
             if (create) {


### PR DESCRIPTION
See https://github.com/MinecraftForge/MinecraftForge/pull/7697 for more information.

The patch is misplaced in some Forge versions, but is done correctly in NeoForge, and we should also replicate the same check in Lithium's patch.