### PR TITLE
Restructure Entity.updateWaterState overwrite so mod mixins work

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/collisions/fluid/EntityMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/collisions/fluid/EntityMixin.java
@@ -127,15 +127,7 @@ public abstract class EntityMixin implements FluidCachingEntity, IForgeEntity {
         this.radium$isInModdedFluid = false;
         this.checkWaterState();
 
-        if (this.radium$isInModdedFluid) {
-            this.handleModdedFluidBehaviors();
-        }
-
-        return this.isInFluidType();
-    }
-
-    private void handleModdedFluidBehaviors() {
-        if (!(this.getVehicle() instanceof BoatEntity)) {
+        if (this.radium$isInModdedFluid && !(this.getVehicle() instanceof BoatEntity)) {
             float fallDistanceModifier = Float.MAX_VALUE;
             boolean canExtinguish = false;
 
@@ -154,6 +146,8 @@ public abstract class EntityMixin implements FluidCachingEntity, IForgeEntity {
                 this.extinguish();
             }
         }
+
+        return this.isInFluidType();
     }
 
     /**


### PR DESCRIPTION
Extracting the code to a helper method had the side effect of breaking redirects on the `fallDistance` field assignment.

Fixes #29